### PR TITLE
Reset action for osc

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -123,6 +123,15 @@ export function getActions() {
 				this.sendCommand(`/10scene/${action.options.item}${zone}`, action.options.zone ? 1 : 0)
 			},
 		},
+		restOSC: {
+			name: 'Reset OSC',
+			options: [
+
+			],
+			callback: (action) => {
+				this.initOSC()
+			},
+		},
 	}
 	return actions
 }

--- a/main.js
+++ b/main.js
@@ -91,6 +91,7 @@ class QuickQInstance extends InstanceBase {
 	}
 
 	initOSC() {
+		console.log("Setting up UPD Socket")
 		this.states = {}
 
 		if (this.listener) {


### PR DESCRIPTION
Add an action to be able to reset the OSC connect if companion stars before the quickq board.