### PR TITLE
feat: add feedback for executes, feedback on/off actions

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -123,6 +123,38 @@ export function getActions() {
 				this.sendCommand(`/10scene/${action.options.item}${zone}`, action.options.activate ? 1 : 0)
 			},
 		},
+		feedbackStart: {
+			name: 'Start feedback',
+			options: [
+				{
+					id: 'feedback_pb',
+					type: 'checkbox',
+					label: 'Playbacks',
+					default: true
+				},
+				{
+					id: 'feedback_exec',
+					type: 'checkbox',
+					label: 'Executes',
+					default: true
+				}
+			],
+			callback: (action) => {
+				let command = ''
+
+				if(action.options.feedback_pb) command += "pb"
+				if(action.options.feedback_pb && action.options.feedback_exec) command += "+"
+				if(action.options.feedback_exec) command += "exec"
+				this.sendCommand(`/feedback/${command}`)
+			},
+		},
+		feedbackStop: {
+			name: 'Stop feedback',
+			options: [],
+			callback: (action) => {
+				this.sendCommand(`/feedback/off`)
+			},
+		},
 		restOSC: {
 			name: 'Reset OSC',
 			options: [],

--- a/feedbacks.js
+++ b/feedbacks.js
@@ -60,8 +60,6 @@ export function getFeedbacks() {
 			},
 		],
 		callback: (feedback) => {
-			//return true
-			//this.log(`Returning feedback for execute ${feedback.options.execute} as ${this.playbacks[`${feedback.options.execute}`]?.state > 0}`)
 			return this.executes[`${feedback.options.execute}`]?.state > 0
 		},
 	}

--- a/feedbacks.js
+++ b/feedbacks.js
@@ -41,5 +41,30 @@ export function getFeedbacks() {
 		},
 	}
 
+	feedbacks['executeState'] = {
+		type: 'boolean',
+		name: 'Execute state',
+		description: 'Change style if the selected execute (1-10) is active',
+		defaultStyle: {
+			color: ColorWhite,
+			bgcolor: ColorGreen,
+		},
+		options: [
+			{
+				id: 'execute',
+				type: 'number',
+				label: 'Execute',
+				default: 1,
+				min: 1,
+				max: 10,
+			},
+		],
+		callback: (feedback) => {
+			//return true
+			//this.log(`Returning feedback for execute ${feedback.options.execute} as ${this.playbacks[`${feedback.options.execute}`]?.state > 0}`)
+			return this.executes[`${feedback.options.execute}`]?.state > 0
+		},
+	}
+
 	return feedbacks
 }

--- a/main.js
+++ b/main.js
@@ -109,7 +109,6 @@ class QuickQInstance extends InstanceBase {
 		this.listener.open()
 		this.listener.on('ready', () => {
 			this.updateStatus(InstanceStatus.Ok)
-			this.log("info", "Module ready")
 			this.sendCommand('/feedback/pb+exec')
 		})
 		this.listener.on('error', (err) => {
@@ -121,15 +120,9 @@ class QuickQInstance extends InstanceBase {
 		})
 
 		this.listener.on('message', (message) => {
-
-			//this.log('info', `Info: message received from console was ${message.args}, sent to ${message.address}.`)
-
 			let value = message?.args[0]?.value
 
 			if (message?.address.match(/\/pb\/[0-9]+$/)) {
-
-				//this.log('info', `Info: pb message received from console was ${message.args}, sent to ${message.address}.`)
-
 				let playbackInfo = message.address.match(/(\/pb\/)([0-9]+)$/)
 
 				if (playbackInfo?.[2]) {
@@ -141,16 +134,11 @@ class QuickQInstance extends InstanceBase {
 				}
 			}
 			else if (message?.address.match(/\/exec\/[0-9]+\/[0-9]+$/)) {
-				//this.log('info', `Info: exec message received from console was ${message.args}, sent to ${message.address}.`)
-				//this.log('info', `${message.args[0].value}`)
-
 				let executeInfo = message.address.match(/(\/exec\/)[0-9]+\/([0-9])+$/)
 
 				if (executeInfo?.[2]) {
 					let num = executeInfo[2]
-					//this.log('info', `Setting state for execute ${num} to ${value}`)
 					this.executes[`${num}`] = { state: value }
-					//this.log('info', `Set state for execute ${num} to ${this.executes[`${num}`].state}`)
 					this.setVariableValues({ [`execute_${num}_state`]: value })
 					this.checkFeedbacks()
 				}

--- a/main.js
+++ b/main.js
@@ -15,6 +15,7 @@ class QuickQInstance extends InstanceBase {
 	async init(config) {
 		this.config = config
 		this.playbacks = {}
+		this.executes = {}
 
 		this.updateStatus(InstanceStatus.Connecting)
 
@@ -108,19 +109,27 @@ class QuickQInstance extends InstanceBase {
 		this.listener.open()
 		this.listener.on('ready', () => {
 			this.updateStatus(InstanceStatus.Ok)
+			this.log("info", "Module ready")
 			this.sendCommand('/feedback/pb+exec')
 		})
 		this.listener.on('error', (err) => {
 			if (err.code == 'EADDRINUSE') {
 				this.log('error', `Error: Selected feedback port ${err.message.split(':')[1]} is already in use.`)
 				this.updateStatus('bad_config', 'Feedback port conflict')
+				
 			}
 		})
 
 		this.listener.on('message', (message) => {
+
+			//this.log('info', `Info: message received from console was ${message.args}, sent to ${message.address}.`)
+
 			let value = message?.args[0]?.value
 
 			if (message?.address.match(/\/pb\/[0-9]+$/)) {
+
+				//this.log('info', `Info: pb message received from console was ${message.args}, sent to ${message.address}.`)
+
 				let playbackInfo = message.address.match(/(\/pb\/)([0-9]+)$/)
 
 				if (playbackInfo?.[2]) {
@@ -131,6 +140,22 @@ class QuickQInstance extends InstanceBase {
 					this.checkFeedbacks()
 				}
 			}
+			else if (message?.address.match(/\/exec\/[0-9]+\/[0-9]+$/)) {
+				//this.log('info', `Info: exec message received from console was ${message.args}, sent to ${message.address}.`)
+				//this.log('info', `${message.args[0].value}`)
+
+				let executeInfo = message.address.match(/(\/exec\/)[0-9]+\/([0-9])+$/)
+
+				if (executeInfo?.[2]) {
+					let num = executeInfo[2]
+					//this.log('info', `Setting state for execute ${num} to ${value}`)
+					this.executes[`${num}`] = { state: value }
+					//this.log('info', `Set state for execute ${num} to ${this.executes[`${num}`].state}`)
+					this.setVariableValues({ [`execute_${num}_state`]: value })
+					this.checkFeedbacks()
+				}
+			}
+
 		})
 	}
 }


### PR DESCRIPTION
Fixes Issue #17.

Adds a pattern match for received feedback related to execute states on the board, similar to playback feedback but boolean because executes are on/off only.

Also adds start/stop commands for feedback, just for general utility - e.g. to restart feedback if the board is shut down and restarted.